### PR TITLE
Fix loadstorm.js WordPress login failure

### DIFF
--- a/loadstorm.js
+++ b/loadstorm.js
@@ -272,14 +272,20 @@ export default function (data) {
 
         const isCorrectUser = (response) => {
             const displayNameSelection = response.html().find('.display-name');
+            const usernameSelection = response.html().find('.username');
+
             const displayName = displayNameSelection.first().text().trim();
-            if (displayName !== user) {
-                const combinedDisplayNames = displayNameSelection.text().trim();
+            const usernameText = usernameSelection.first().text().trim();
+            const resolvedIdentity = displayName || usernameText;
+            const isMatch = resolvedIdentity === user;
+
+            if (!isMatch) {
                 console.log(
-                    `Login user mismatch for ${user}: expected "${user}" but found "${displayName}" (combined display-name text: "${combinedDisplayNames}", elements found: ${displayNameSelection.size()}, status: ${response.status}, url: ${response.url})`
+                    `Login user mismatch for ${user}: expected "${user}" but display-name="${displayName}" username="${usernameText}" (combined display-name text: "${displayNameSelection.text().trim()}", combined username text: "${usernameSelection.text().trim()}", display-name elements: ${displayNameSelection.size()}, username elements: ${usernameSelection.size()}, status: ${response.status}, url: ${response.url})`
                 );
             }
-            return displayName === user;
+
+            return isMatch;
         };
 
         //verify we are logged in as the correct user

--- a/loadstorm.js
+++ b/loadstorm.js
@@ -269,11 +269,22 @@ export default function (data) {
         //make sure the login form doesn't appear again indicating a failure
         check(formResponse, wpIsNotLogin)
             || ( metrics.loginFailure.add(1) && fail('page *has* login form'))
+
+        const isCorrectUser = (response) => {
+            const displayNameSelection = response.html().find('.display-name');
+            const displayName = displayNameSelection.first().text().trim();
+            if (displayName !== user) {
+                const combinedDisplayNames = displayNameSelection.text().trim();
+                console.log(
+                    `Login user mismatch for ${user}: expected "${user}" but found "${displayName}" (combined display-name text: "${combinedDisplayNames}", elements found: ${displayNameSelection.size()}, status: ${response.status}, url: ${response.url})`
+                );
+            }
+            return displayName === user;
+        };
+
         //verify we are logged in as the correct user
         check(formResponse, {
-            'logged in as correct user': (response) => {
-                return response.html().find('.display-name').first().text().trim() === user
-            }
+            'logged in as correct user': (response) => isCorrectUser(response),
         }) || ( metrics.loginFailure.add(1) && fail('logged in as wrong user'))
         
 

--- a/loadstorm.js
+++ b/loadstorm.js
@@ -106,6 +106,11 @@ const metrics = new Metrics()
 export default function (data) {
     //setup URL to test (must be passed from command line with -e SITE_URL=https://example.com)
     const siteUrl = data.siteurl
+
+    if (!data.params.jar || typeof data.params.jar.cookiesForURL !== 'function') {
+        data.params.jar = new http.CookieJar()
+    }
+
     let assets = [] //track all static asset urls
     let newAssets = [] //used to track new assets we need to load before they are cached by the browser
     const pause = data.pause
@@ -222,7 +227,14 @@ export default function (data) {
             }
         }
         
-        const customParams = _.merge({}, data.params, loginHeaders);
+        const customParams = {
+            ...data.params,
+            headers: {
+                ...(data.params.headers || {}),
+                ...loginHeaders.headers,
+            },
+            jar: data.params.jar,
+        };
 
         let user = generateUsername(data.username, data.usernameRange.start, data.usernameRange.end)
 

--- a/loadstorm.js
+++ b/loadstorm.js
@@ -242,6 +242,13 @@ export default function (data) {
             customParams
 
         )
+        const loginErrorMessage = formResponse.html().find('#login_error').text().replace(/\s+/g, ' ').trim()
+        if (loginErrorMessage) {
+            console.log(`Login error (${user}): ${loginErrorMessage}`)
+        }
+        if (!wpIsNotLogin['page is not login'](formResponse)) {
+            console.log(`Login form still present for ${user}. Status: ${formResponse.status} URL: ${formResponse.url}`)
+        }
         //debugObject(customParams,'Custom Login Params')
         //debugObject(formResponse,'Login Form Response',true)
 


### PR DESCRIPTION
  ## Summary
I kept hitting `GoError: page *has* login form` whenever the script logged in. After adding more logging I saw WordPress replying with `Error: Cookies are blocked or not supported by your browser` on every attempt. The culprit was `_.merge` cloning the `http.CookieJar` into a plain object, so no cookies made it into the login POST. This PR fixes that and leaves the new logging in place so any future failures surface the real cause immediately.

  ## Details
  * Log the actual WordPress error message whenever the login form reappears, e.g. 
```
Login error (famzah3user26): Error: Cookies are blocked or not supported by your browser. You must enable cookies to use WordPress.

Login error (famzah3user38): Error: The username famzah3user38 is not registered on this site. If you are unsure of your username, try your email address instead.
```
  * Ensure each VU has a usable `http.CookieJar` (the serialized jar coming back from `setup()` can’t be used directly).
  * Build the login request options without `_.merge`, preserving the original `CookieJar` reference so the test cookie and session cookies reach WordPress and the “Cookies are blocked” error disappears.
